### PR TITLE
fix(theme): use resolvedTheme for toggle to ensure visible change

### DIFF
--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -7,13 +7,13 @@ import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
 
   return (
     <Button
       variant="ghost"
       size="icon"
-      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+      onClick={() => setTheme(resolvedTheme === "light" ? "dark" : "light")}
       className="rounded-full"
     >
       <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />


### PR DESCRIPTION
## Summary:
- Use `resolvedTheme` instead of `theme` in theme toggle to ensure clicking always produces a visible change
- Fixes UX issue where clicking toggle in "system" mode appeared to do nothing when system preference matched the next theme in cycle

## Test plan
- Set OS to light mode
- Open app (defaults to system theme, displays light)
- Click theme toggle
- Theme should immediately switch to dark (not stay light)